### PR TITLE
Add language server workspace configuration support to Zed

### DIFF
--- a/src/Zed/Readme.md
+++ b/src/Zed/Readme.md
@@ -22,3 +22,35 @@ chmod +x "/home/You/.local/share/zed/extensions/work/dotrush/LanguageServer/dotr
 ![image](https://github.com/JaneySprings/DotRush/raw/main/assets/image5.jpg)
 
 *This extension based on the [csharp](https://github.com/zed-extensions/csharp) extension configs.*
+
+## Configuration
+
+DotRush extension can be configured in Zed by creating a [settings.json file](https://zed.dev/docs/configuring-zed#settings-files) in your project root directory. 
+
+### Basic Configuration
+
+You only need to provide the `projectOrSolutionFiles` option at minimum, but can customize the behavior further with additional settings as needed.
+
+```json
+{
+    "lsp": {
+        "dotrush": {
+            "settings": {
+                "dotrush": {
+                    "roslyn": {
+                        // Paths to project or solution files to load
+                        "projectOrSolutionFiles": [
+                            "/path/to/your/solution.sln"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+### All Configuration Options
+
+
+All available configuration options can be found in the DotRush extension's [package.json](https://github.com/JaneySprings/DotRush/blob/main/package.json) file. Any option under the `dotrush.roslyn` namespace can be used in your settings file with the structure shown above.

--- a/src/Zed/src/lib.rs
+++ b/src/Zed/src/lib.rs
@@ -1,5 +1,7 @@
 use std::fs;
 use zed_extension_api::{self as zed, LanguageServerId, Result, Worktree};
+use zed::serde_json;
+use zed_extension_api::settings::LspSettings;
 
 struct DotRushExtension {}
 impl DotRushExtension {
@@ -72,6 +74,18 @@ impl zed::Extension for DotRushExtension {
             args: Default::default(),
             env: Default::default(),
         })
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        _language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        let settings = LspSettings::for_worktree("dotrush", worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings.clone())
+            .unwrap_or_default();
+        Ok(Some(settings))
     }
 }
 


### PR DESCRIPTION
#45

this would allow to configure Dotrush just like: https://zed.dev/docs/languages/deno#deno-configuration

.zed/settings.json
```json
{
    "lsp": {
        "dotrush": {
            "settings": {
                "dotrush": {
                    "roslyn": {
                        "showItemsFromUnimportedNamespaces": true,
                        "targetTypedCompletionFilter": true,
                        "skipUnrecognizedProjects": false,
                        "loadMetadataForReferencedProjects": false,
                        "restoreProjectsBeforeLoading": true,
                        "compileProjectsAfterLoading": true,
                        "applyWorkspaceChanges": false,
                        "useMultitargetDiagnostics": true,
                        "compilerDiagnosticsScope": 1,
                        "analyzerDiagnosticsScope": 1,
                        "enableAnalyzers": true,
                        "dotnetSdkDirectory": "",
                        "workspaceProperties": [],
                        "analyzerAssemblies": [],
                        "projectOrSolutionFiles": []
                    }
                }
            }
        }
    }
}

```