### PR TITLE
Support for nested test classes

### DIFF
--- a/src/DotRush.Debugging.NetCore/Testing/Explorer/TestExplorer.cs
+++ b/src/DotRush.Debugging.NetCore/Testing/Explorer/TestExplorer.cs
@@ -16,12 +16,17 @@ public class TestExplorer : TestExplorerSyntaxWalker {
     private List<TestFixture> DiscoverTestsCore(string projectDirectory) {
         var result = new List<TestFixture>();
         var fixtures = GetFixtures(projectDirectory);
+        var fixturesDict = fixtures.ToDictionary(f => f.Id);
+        
+        // Process fixtures that are not nested (no parent fixture)
         foreach (var fixture in fixtures) {
-            if (fixture.IsAbstract)
+            if (fixture.IsAbstract || !string.IsNullOrEmpty(fixture.ParentFixtureId))
                 continue;
 
             fixture.Resolve(fixtures);
-            if (fixture.TestCases.Count != 0)
+            
+            // Only add top-level fixtures with tests or child fixtures
+            if (fixture.TestCases.Count != 0 || fixture.ChildFixtures.Count != 0)
                 result.Add(fixture);
         }
 

--- a/src/DotRush.Debugging.NetCore/Testing/Explorer/TestExplorerSyntaxWalker.cs
+++ b/src/DotRush.Debugging.NetCore/Testing/Explorer/TestExplorerSyntaxWalker.cs
@@ -14,6 +14,7 @@ public abstract class TestExplorerSyntaxWalker {
         var result = new Dictionary<string, TestFixture>();
         var options = new CSharpParseOptions(preprocessorSymbols: preprocessorSymbols);
         var documentPaths = Directory.GetFiles(projectDirectory, "*.cs", SearchOption.AllDirectories);
+        
         foreach (var documentPath in documentPaths) {
             var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(documentPath), options);
             var root = tree.GetRoot();
@@ -22,7 +23,9 @@ public abstract class TestExplorerSyntaxWalker {
             foreach (var nspace in namespaces) {
                 var classes = nspace.DescendantNodes().OfType<ClassDeclarationSyntax>();
                 foreach (var klass in classes) {
-                    var fixtureId = $"{nspace.Name}.{klass.Identifier.Text}";
+                    var fullClassName = GetFullClassName(klass);
+                    var fixtureId = $"{nspace.Name}.{fullClassName}";
+                    
                     if (!result.TryGetValue(fixtureId, out var fixture)) {
                         fixture = new TestFixture(fixtureId, klass.Identifier.Text, documentPath);
                         fixture.IsAbstract = klass.Modifiers.Any(p => p.IsKind(SyntaxKind.AbstractKeyword));
@@ -37,10 +40,12 @@ public abstract class TestExplorerSyntaxWalker {
                 }
             }
         }
+        
         return result.Values;
     }
     protected IEnumerable<TestCase> GetTestCases(ClassDeclarationSyntax fixture, TestFixture parent, string documentPath) {
-        var methods = fixture.DescendantNodes().OfType<MethodDeclarationSyntax>().Where(node => {
+        // Only get methods that are direct children of this class, not from nested classes
+        var methods = fixture.ChildNodes().OfType<MethodDeclarationSyntax>().Where(node => {
             // XUnit
             var hasFactAttribute = node.AttributeLists.Any(p => p.Attributes.Any(a => a.Name.ToString().EndsWith("Fact", StringComparison.InvariantCulture)));
             var hasTheoryAttribute = node.AttributeLists.Any(p => p.Attributes.Any(a => a.Name.ToString().EndsWith("Theory", StringComparison.InvariantCulture)));
@@ -76,5 +81,18 @@ public abstract class TestExplorerSyntaxWalker {
 
         var baseTypesIdentifierTexts = klass.BaseList.Types.Select(p => p.Type).OfType<SimpleNameSyntax>().Select(p => p.Identifier.Text);
         return baseTypesIdentifierTexts.FirstOrDefault(it => !it.StartsWith("I", StringComparison.OrdinalIgnoreCase));
+    }
+
+    protected string GetFullClassName(ClassDeclarationSyntax klass) {
+        var classNames = new List<string>();
+        var currentNode = klass;
+
+        // Walk up the syntax tree to collect all containing class names
+        while (currentNode != null) {
+            classNames.Insert(0, currentNode.Identifier.Text);
+            currentNode = currentNode.Parent?.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+        }
+
+        return string.Join("+", classNames);
     }
 }

--- a/src/DotRush.Debugging.NetCore/Testing/Models/TestFixture.cs
+++ b/src/DotRush.Debugging.NetCore/Testing/Models/TestFixture.cs
@@ -9,14 +9,17 @@ public class TestFixture {
     [JsonPropertyName("filePath")] public string FilePath { get; set; }
     [JsonPropertyName("range")] public Range? Range { get; set; }
     [JsonPropertyName("children")] public HashSet<TestCase> TestCases { get; set; }
+    [JsonPropertyName("childFixtures")] public HashSet<TestFixture> ChildFixtures { get; set; }
     [JsonIgnore] public bool IsAbstract { get; set; }
     [JsonIgnore] public string? BaseFixtureName { get; set; }
+    [JsonIgnore] public string? ParentFixtureId { get; set; }
 
     public TestFixture(string id, string name, string filePath) {
         Id = id;
         Name = name;
         FilePath = filePath;
         TestCases = new HashSet<TestCase>();
+        ChildFixtures = new HashSet<TestFixture>();
     }
 
     public void Resolve(IEnumerable<TestFixture> fixtures) {
@@ -32,5 +35,10 @@ public class TestFixture {
         }
 
         BaseFixtureName = null;
+    }
+    
+    public TestFixture UpdateParentId(string parentId) {
+        ParentFixtureId = parentId;
+        return this;
     }
 }

--- a/src/VSCode/models/test.ts
+++ b/src/VSCode/models/test.ts
@@ -7,6 +7,7 @@ export interface TestFixture {
     filePath: string;
     range: Range | null;
     children: TestCase[];
+    childFixtures: TestFixture[];
 }
 
 export interface TestCase {
@@ -29,8 +30,23 @@ export class TestExtensions {
         const item = controller.createTestItem(fixture.id, `${Icons.module} ${fixture.name}`, Uri.file(fixture.filePath));
         if (fixture.range !== null)
             item.range = fixture.range;
-        if (fixture.children !== null && fixture.children !== undefined)
-            item.children.replace(fixture.children.map(tc => TestExtensions.testCaseToTestItem(tc, controller)));
+            
+        // Create a collection of test items for both test cases and child fixtures
+        const childItems: TestItem[] = [];
+        
+        // Add test cases
+        if (fixture.children !== null && fixture.children !== undefined) {
+            childItems.push(...fixture.children.map(tc => TestExtensions.testCaseToTestItem(tc, controller)));
+        }
+        
+        // Add child fixtures
+        if (fixture.childFixtures !== null && fixture.childFixtures !== undefined) {
+            childItems.push(...fixture.childFixtures.map(cf => TestExtensions.fixtureToTestItem(cf, controller)));
+        }
+        
+        // Replace the children collection with all items
+        item.children.replace(childItems);
+        
         return item;
     }
     public static testCaseToTestItem(testCase: TestCase, controller: TestController): TestItem {


### PR DESCRIPTION
This change adds support for nested test classes. For example:

``` c#
public class <ClassUnderTest> {
  public class <MethodUnderTest>Should {
    public void DoXWhenY() {}
    public void DoAWhenB() {}
  }

  public class <OtherMethodUnderTest>Should {
    public void Do1When 2() {}
  }
}
```

In additon the Test Explorer now shows enqueued tests:

![image](https://github.com/user-attachments/assets/96a05769-292f-4844-9cb9-88ca9ed16d07)

