### PR TITLE
Make diagnostic help links clickable

### DIFF
--- a/src/DotRush.Roslyn.Server/Extensions/DiagnosticsExtensions.cs
+++ b/src/DotRush.Roslyn.Server/Extensions/DiagnosticsExtensions.cs
@@ -30,13 +30,20 @@ public static class DiagnosticExtensions {
         throw new NotImplementedException($"Unknown diagnostic severity: {severity}");
     }
     public static ProtocolModels.Diagnostic ToServerDiagnostic(this DiagnosticContext context, DiagnosticsFormat format) {
-        return new ProtocolModels.Diagnostic() {
+        var diagnostic = new ProtocolModels.Diagnostic() {
             Code = context.Diagnostic.Id,
             Message = context.Diagnostic.GetSubject(),
             Range = context.Diagnostic.Location.ToRange(),
             Severity = context.Diagnostic.Severity.ToServerSeverity(format),
             Source = context.SourceName,
         };
+
+        string helpUriString = context.Diagnostic.Descriptor.HelpLinkUri;
+        if (!string.IsNullOrEmpty(helpUriString) && Uri.TryCreate(helpUriString, UriKind.Absolute, out Uri? helpUri)) {
+            diagnostic.CodeDescription = new(helpUri);
+        }
+
+        return diagnostic;
     }
 
     public static bool IsHiddenInUI(this DiagnosticContext context) {

--- a/src/DotRush.Roslyn.Server/Extensions/DiagnosticsExtensions.cs
+++ b/src/DotRush.Roslyn.Server/Extensions/DiagnosticsExtensions.cs
@@ -38,10 +38,9 @@ public static class DiagnosticExtensions {
             Source = context.SourceName,
         };
 
-        string helpUriString = context.Diagnostic.Descriptor.HelpLinkUri;
-        if (!string.IsNullOrEmpty(helpUriString) && Uri.TryCreate(helpUriString, UriKind.Absolute, out Uri? helpUri)) {
-            diagnostic.CodeDescription = new(helpUri);
-        }
+        var helpUriString = context.Diagnostic.Descriptor.HelpLinkUri;
+        if (!string.IsNullOrEmpty(helpUriString) && Uri.TryCreate(helpUriString, UriKind.Absolute, out Uri? helpUri))
+            diagnostic.CodeDescription = new ProtocolModels.CodeDescription(helpUri);
 
         return diagnostic;
     }


### PR DESCRIPTION
Fixes #90

## Root cause

The issue is in the `ToServerDiagnostic` extension method, which converts Roslyn diagnostics to LSP diagnostics. The method is not mapping the `HelpLinkUri` from the Roslyn diagnostic to the LSP `CodeDescription.Href` property.

**Problematic code:**
```csharp
public static ProtocolModels.Diagnostic ToServerDiagnostic(
    this DiagnosticContext context,
    DiagnosticsFormat format) {
    return new ProtocolModels.Diagnostic() {
        Code = context.Diagnostic.Id,
        Message = context.Diagnostic.GetSubject(),
        Range = context.Diagnostic.Location.ToRange(),
        Severity = context.Diagnostic.Severity.ToServerSeverity(format),
        Source = context.SourceName,
        // Missing: CodeDescription with HelpUri!
    };
}
```

## Solution

Add the `CodeDescription` property to map the help URI:

**New code:**
```csharp
public static ProtocolModels.Diagnostic ToServerDiagnostic(
    this DiagnosticContext context,
    DiagnosticsFormat format) {
    var diagnostic = new ProtocolModels.Diagnostic() {
        Code = context.Diagnostic.Id,
        Message = context.Diagnostic.GetSubject(),
        Range = context.Diagnostic.Location.ToRange(),
        Severity = context.Diagnostic.Severity.ToServerSeverity(format),
        Source = context.SourceName,
    };

    string helpUriString = context.Diagnostic.Descriptor.HelpLinkUri;
    if (!string.IsNullOrEmpty(helpUriString) && Uri.TryCreate(helpUriString, UriKind.Absolute, out Uri? helpUri)) {
        diagnostic.CodeDescription = new(helpUri);
    }

    return diagnostic;
}
```

Although I'm not sure what to do with invalid or non-absolute URIs, I guess ignoring them is fine.

## Results

<img width="895" height="112" alt="image" src="https://github.com/user-attachments/assets/8f195663-342a-46c3-9a7b-ede357eefac2" />

After applying the fix:
1. Diagnostics with help URIs now show clickable links.
2. Links properly navigate to the analyzer documentation.

**Note:** I only tested locally in regular VSCode.
