### PR TITLE
Fix Zed extension build by using new release assets names for osx and win

### DIFF
--- a/src/AltEditors/Zed/src/lib.rs
+++ b/src/AltEditors/Zed/src/lib.rs
@@ -24,9 +24,9 @@ impl DotRushExtension {
         let asset_name = format!(
             "DotRush.Bundle.Server_{os}-{arch}.zip",
             os = match platform {
-                zed::Os::Mac => "osx",
+                zed::Os::Mac => "darwin",
                 zed::Os::Linux => "linux",
-                zed::Os::Windows => "win",
+                zed::Os::Windows => "win32",
             },
             arch = match arch {
                 zed::Architecture::Aarch64 => "arm64",


### PR DESCRIPTION


<!--
🚨 Pull Request Guidelines — Please Read Before Submitting

I want to keep this project maintainable, understandable, and clean.

Pull Requests will only be considered if they meet *all* of the following rules:

✅ **Type of Change**
- Must be a **bug fix** OR
- A **small and focused feature**

🚫 **What will be rejected**
- PRs that **rewrite or restructure large parts of the code**
- PRs that **introduce complex changes without clear explanation**
- PRs with code from AI **without proper testing**

💡 If Your PR Is Rejected

If this pull request doesn’t meet the guidelines and is closed, you are **still welcome to maintain your work in your own fork** of the project. Forks are a great way to experiment, extend functionality, or customize the project for your own use.

Thank you for contributing and respecting the project’s scope and maintainability goals!

-->

## Description

Looks like in the last [release](https://github.com/JaneySprings/DotRush/releases/tag/2025.09-service2) the MacOS and Windows assets naming changed. 

[2025.09-service2](https://github.com/JaneySprings/DotRush/releases/tag/2025.09-service2)
<img width="633" height="543" alt="image" src="https://github.com/user-attachments/assets/499e577a-c03e-4928-b3f2-d7031723c081" />

[2025.09-service1](https://github.com/JaneySprings/DotRush/releases/tag/2025.09-service1)
<img width="587" height="418" alt="image" src="https://github.com/user-attachments/assets/8a67cdf5-79b8-4446-8868-900a70067f71" />
