### PR TITLE
Fix NUnit test filtering with runsettings Category conditions

### DIFF
--- a/src/DotRush.Debugging.NetCore/Extensions/NUnitFilterHack.cs
+++ b/src/DotRush.Debugging.NetCore/Extensions/NUnitFilterHack.cs
@@ -20,7 +20,7 @@ public static class NUnitFilterExtensions {
         var whereParts = new List<string>();
         if (typeFilters.Length > 0) {
             var vsFilters = typeFilters.Select(f => $"test==/{f}/").ToArray();
-            whereParts.Add("(" + string.Join(" or ", vsFilters) + ")");
+            whereParts.Add(string.Concat("(", string.Join(" or ", vsFilters), ")"));
         }
 
         var runSettingsFilter = ExtractTestCaseFilterFromRunSettings(runSettings);
@@ -124,27 +124,27 @@ public static class NUnitFilterExtensions {
                 return null;
 
             if (expr[0] == '(' && expr[^1] == ')' && MatchingParens(expr))
-                return Parse(expr.Substring(1, expr.Length - 2));
+                return Parse(expr.AsSpan(1, expr.Length - 2).ToString());
 
             var orParts = SplitTop(expr, '|');
             if (orParts.Count > 1) {
                 var parsedParts = orParts.Select(p => Parse(p) ?? string.Empty).Where(p => !string.IsNullOrEmpty(p));
                 var result = string.Join(" or ", parsedParts);
-                return "(" + result + ")";
+                return string.Concat("(", result, ")");
             }
 
             var andParts = SplitTop(expr, '&');
             if (andParts.Count > 1) {
                 var parsedParts = andParts.Select(p => Parse(p) ?? string.Empty).Where(p => !string.IsNullOrEmpty(p));
                 var result = string.Join(" and ", parsedParts);
-                return "(" + result + ")";
+                return string.Concat("(", result, ")");
             }
 
             if (expr.StartsWith("Category=", StringComparison.OrdinalIgnoreCase))
-                return "cat==" + expr.Substring("Category=".Length);
+                return string.Concat("cat==", expr.AsSpan("Category=".Length));
 
             if (expr.StartsWith("Category!=", StringComparison.OrdinalIgnoreCase))
-                return "cat!=" + expr.Substring("Category!=".Length);
+                return string.Concat("cat!=", expr.AsSpan("Category!=".Length));
 
             // unrecognized leaf (e.g., FullyQualifiedName, traits other than Category) → ignore
             return null;
@@ -171,12 +171,12 @@ public static class NUnitFilterExtensions {
                 if (c == '(') depth++;
                 else if (c == ')') depth--;
                 else if (c == op && depth == 0) {
-                    parts.Add(s.Substring(last, i - last));
+                    parts.Add(s.AsSpan(last, i - last).ToString());
                     last = i + 1;
                 }
             }
             if (last < s.Length)
-                parts.Add(s.Substring(last));
+                parts.Add(s.AsSpan(last).ToString());
             return parts;
         }
 

--- a/src/DotRush.Debugging.NetCore/Extensions/NUnitFilterHack.cs
+++ b/src/DotRush.Debugging.NetCore/Extensions/NUnitFilterHack.cs
@@ -1,17 +1,46 @@
 using System.Xml.Linq;
 using DotRush.Common.Extensions;
+using DotRush.Common.Logging;
 
 namespace DotRush.Debugging.NetCore.Extensions;
 
 // https://github.com/nunit/nunit-vs-adapter/issues/71
 public static class NUnitFilterExtensions {
-    public static string? UpdateRunSettingsWithNUnitFilter(string? runSettings, string[] testAssemblies, string[] typeFilters) {
-        if (!testAssemblies.Any(IsNUnitAssembly))
-            return runSettings;
 
-        var whereFilter = string.Join(" or ", typeFilters.Select(filter => $"test==/{filter}/"));
-        if (string.IsNullOrEmpty(whereFilter))
+    private static readonly CurrentClassLogger currentClassLogger = new(nameof(NUnitFilterExtensions));
+
+    public static string? UpdateRunSettingsWithNUnitFilter(string? runSettings, string[] testAssemblies, string[] typeFilters) {
+        currentClassLogger.Debug($"UpdateRunSettingsWithNUnitFilter: {testAssemblies.Length} assemblies, {typeFilters.Length} filters");
+
+        if (!testAssemblies.Any(IsNUnitAssembly)) {
+            currentClassLogger.Debug("No NUnit assemblies found");
             return runSettings;
+        }
+
+        var whereParts = new List<string>();
+        if (typeFilters.Length > 0) {
+            var vsFilters = typeFilters.Select(f => $"test==/{f}/").ToArray();
+            whereParts.Add("(" + string.Join(" or ", vsFilters) + ")");
+        }
+
+        var runSettingsFilter = ExtractTestCaseFilterFromRunSettings(runSettings);
+        if (!string.IsNullOrEmpty(runSettingsFilter)) {
+            var translated = TranslateRunSettingsCategoryFilter(runSettingsFilter);
+            if (!string.IsNullOrEmpty(translated))
+                whereParts.Add(translated);
+        }
+
+        var whereFilter = string.Join(" and ", whereParts);
+
+        // If we have NUnit assemblies but no specific filters, create empty NUnit settings
+        if (whereParts.Count == 0) {
+            currentClassLogger.Debug("Creating empty NUnit settings");
+            if (string.IsNullOrEmpty(runSettings))
+                return GetNUnitRunSettings("");
+            return UpdateNUnitRunSettings(runSettings, "");
+        }
+
+        currentClassLogger.Debug($"Creating NUnit settings with filter: '{whereFilter}'");
         if (string.IsNullOrEmpty(runSettings))
             return GetNUnitRunSettings(whereFilter);
 
@@ -48,8 +77,112 @@ public static class NUnitFilterExtensions {
         });
     }
     private static bool IsNUnitAssembly(string assemblyPath) {
-        var assemblyDirectory = Path.GetDirectoryName(assemblyPath)!;
-        var assemblies = Directory.GetFiles(assemblyDirectory, "*.dll", SearchOption.TopDirectoryOnly);
-        return assemblies.Any(a => Path.GetFileName(a).Contains("NUnit", StringComparison.OrdinalIgnoreCase));
+        try {
+            if (Path.GetFileName(assemblyPath).Contains("NUnit", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            var assemblyDirectory = Path.GetDirectoryName(assemblyPath);
+            if (string.IsNullOrEmpty(assemblyDirectory) || !Directory.Exists(assemblyDirectory))
+                return false;
+
+            var assemblies = Directory.GetFiles(assemblyDirectory, "*.dll", SearchOption.TopDirectoryOnly);
+            return assemblies.Any(a => Path.GetFileName(a).Contains("NUnit", StringComparison.OrdinalIgnoreCase));
+        }
+        catch (Exception) {
+            return false;
+        }
     }
+
+    private static string? ExtractTestCaseFilterFromRunSettings(string? runSettings) {
+        if (string.IsNullOrEmpty(runSettings))
+            return null;
+
+        try {
+            var xdoc = System.Xml.Linq.XDocument.Parse(runSettings);
+            var filter = xdoc.Root?
+                .Element("RunConfiguration")?
+                .Element("TestCaseFilter")?
+                .Value?
+                .Trim();
+            currentClassLogger.Debug($"ExtractTestCaseFilterFromRunSettings: '{filter}'");
+            return filter;
+        } catch (Exception ex) {
+            currentClassLogger.Debug($"ExtractTestCaseFilterFromRunSettings failed: {ex.Message}");
+            return null;
+        }
+    }
+
+    public static string? TranslateRunSettingsCategoryFilter(string filter) {
+        if (string.IsNullOrWhiteSpace(filter))
+            return null;
+
+        currentClassLogger.Debug($"TranslateRunSettingsCategoryFilter input: '{filter}'");
+        filter = filter.Replace(" ", string.Empty);
+
+        string? Parse(string expr) {
+            if (expr.Length == 0)
+                return null;
+
+            if (expr[0] == '(' && expr[^1] == ')' && MatchingParens(expr))
+                return Parse(expr.Substring(1, expr.Length - 2));
+
+            var orParts = SplitTop(expr, '|');
+            if (orParts.Count > 1) {
+                var parsedParts = orParts.Select(p => Parse(p) ?? string.Empty).Where(p => !string.IsNullOrEmpty(p));
+                var result = string.Join(" or ", parsedParts);
+                return "(" + result + ")";
+            }
+
+            var andParts = SplitTop(expr, '&');
+            if (andParts.Count > 1) {
+                var parsedParts = andParts.Select(p => Parse(p) ?? string.Empty).Where(p => !string.IsNullOrEmpty(p));
+                var result = string.Join(" and ", parsedParts);
+                return "(" + result + ")";
+            }
+
+            if (expr.StartsWith("Category=", StringComparison.OrdinalIgnoreCase))
+                return "cat==" + expr.Substring("Category=".Length);
+
+            if (expr.StartsWith("Category!=", StringComparison.OrdinalIgnoreCase))
+                return "cat!=" + expr.Substring("Category!=".Length);
+
+            // unrecognized leaf (e.g., FullyQualifiedName, traits other than Category) → ignore
+            return null;
+        }
+
+        static bool MatchingParens(string s) {
+            int depth = 0;
+            for (int i = 0; i < s.Length; i++) {
+                if (s[i] == '(') depth++;
+                else if (s[i] == ')') {
+                    depth--;
+                    if (depth == 0 && i != s.Length - 1)
+                        return false;
+                }
+            }
+            return depth == 0;
+        }
+
+        static List<string> SplitTop(string s, char op) {
+            var parts = new List<string>();
+            int depth = 0, last = 0;
+            for (int i = 0; i < s.Length; i++) {
+                var c = s[i];
+                if (c == '(') depth++;
+                else if (c == ')') depth--;
+                else if (c == op && depth == 0) {
+                    parts.Add(s.Substring(last, i - last));
+                    last = i + 1;
+                }
+            }
+            if (last < s.Length)
+                parts.Add(s.Substring(last));
+            return parts;
+        }
+
+        var result = Parse(filter);
+        currentClassLogger.Debug($"TranslateRunSettingsCategoryFilter result: '{result}'");
+        return result;
+    }
+
 }

--- a/src/DotRush.Debugging.NetCore/Extensions/NUnitFilterHack.cs
+++ b/src/DotRush.Debugging.NetCore/Extensions/NUnitFilterHack.cs
@@ -20,7 +20,7 @@ public static class NUnitFilterExtensions {
         var whereParts = new List<string>();
         if (typeFilters.Length > 0) {
             var vsFilters = typeFilters.Select(f => $"test==/{f}/").ToArray();
-            whereParts.Add(string.Concat("(", string.Join(" or ", vsFilters), ")"));
+            whereParts.Add("(" + string.Join(" or ", vsFilters) + ")");
         }
 
         var runSettingsFilter = ExtractTestCaseFilterFromRunSettings(runSettings);
@@ -87,8 +87,7 @@ public static class NUnitFilterExtensions {
 
             var assemblies = Directory.GetFiles(assemblyDirectory, "*.dll", SearchOption.TopDirectoryOnly);
             return assemblies.Any(a => Path.GetFileName(a).Contains("NUnit", StringComparison.OrdinalIgnoreCase));
-        }
-        catch (Exception) {
+        } catch (Exception) {
             return false;
         }
     }
@@ -124,20 +123,20 @@ public static class NUnitFilterExtensions {
                 return null;
 
             if (expr[0] == '(' && expr[^1] == ')' && MatchingParens(expr))
-                return Parse(expr.AsSpan(1, expr.Length - 2).ToString());
+                return Parse(expr.Substring(1, expr.Length - 2));
 
             var orParts = SplitTop(expr, '|');
             if (orParts.Count > 1) {
                 var parsedParts = orParts.Select(p => Parse(p) ?? string.Empty).Where(p => !string.IsNullOrEmpty(p));
                 var result = string.Join(" or ", parsedParts);
-                return string.Concat("(", result, ")");
+                return "(" + result + ")";
             }
 
             var andParts = SplitTop(expr, '&');
             if (andParts.Count > 1) {
                 var parsedParts = andParts.Select(p => Parse(p) ?? string.Empty).Where(p => !string.IsNullOrEmpty(p));
                 var result = string.Join(" and ", parsedParts);
-                return string.Concat("(", result, ")");
+                return "(" + result + ")";
             }
 
             if (expr.StartsWith("Category=", StringComparison.OrdinalIgnoreCase))
@@ -171,12 +170,12 @@ public static class NUnitFilterExtensions {
                 if (c == '(') depth++;
                 else if (c == ')') depth--;
                 else if (c == op && depth == 0) {
-                    parts.Add(s.AsSpan(last, i - last).ToString());
+                    parts.Add(s.Substring(last, i - last));
                     last = i + 1;
                 }
             }
             if (last < s.Length)
-                parts.Add(s.AsSpan(last).ToString());
+                parts.Add(s.Substring(last));
             return parts;
         }
 


### PR DESCRIPTION
## Description

This PR adds support for filtering NUnit tests by `[Category]` attributes when using `.runsettings` in DotRush Test Explorer.  

### Motivation
Currently, `<TestCaseFilter>` entries in `.runsettings` are not correctly applied to NUnit tests because the NUnit adapter requires `<NUnit><Where>` expressions instead. This caused all tests to run, regardless of category filters.

### Changes
- Detect NUnit assemblies when starting a test session.
- Translate `<TestCaseFilter>` expressions into NUnit-compatible `<Where>` clauses:
  - `Category=foo` → `cat==foo`
  - `Category!=bar` → `cat!=bar`
  - Combined expressions (`&` / `|`) now respected when properly escaped in XML.
- Merge filters from:
  - RunSettings `<TestCaseFilter>`
  - VS Code test selection (`typeFilters`)
- Update `NUnitFilterExtensions` with translation + helper logic.

### Examples

#### RunSettings
```xml
<RunSettings>
  <RunConfiguration>
    <TestCaseFilter>Category=foo</TestCaseFilter>
  </RunConfiguration>
</RunSettings>
```

Runs only tests with `[Category("foo")]`.

```xml
<RunSettings>
  <RunConfiguration>
    <TestCaseFilter>Category!=bar</TestCaseFilter>
  </RunConfiguration>
</RunSettings>
```

Excludes `[Category("bar")]` tests.

### Impact
- Makes DotRush Test Explorer consistent with `dotnet test --filter` behavior.
- Keeps MSTest/xUnit unchanged (still uses `<TestCaseFilter>` directly).
- Improves developer productivity by allowing category-based filtering directly in VS Code.