### PR TITLE
Fix zed extension `binary_path` on windows

### DIFF
--- a/src/AltEditors/Zed/src/lib.rs
+++ b/src/AltEditors/Zed/src/lib.rs
@@ -6,8 +6,13 @@ use zed_extension_api::settings::LspSettings;
 struct DotRushExtension {}
 impl DotRushExtension {
     fn language_server_binary(&mut self, language_server_id: &LanguageServerId) -> Result<String> {
+        let (platform, arch) = zed::current_platform();
+
         let binary_dir = "./LanguageServer".to_string();
-        let binary_path = "./LanguageServer/DotRush".to_string();
+        let binary_path = match platform {
+            zed::Os::Windows => "./LanguageServer/DotRush.exe",
+            _ => "./LanguageServer/DotRush"
+        }.to_string();
         if fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
             return Ok(binary_path);
         }
@@ -20,7 +25,6 @@ impl DotRushExtension {
             },
         )?;
 
-        let (platform, arch) = zed::current_platform();
         let asset_name = format!(
             "DotRush.Bundle.Server_{os}-{arch}.zip",
             os = match platform {


### PR DESCRIPTION
<!--
🚨 Pull Request Guidelines — Please Read Before Submitting

I want to keep this project maintainable, understandable, and clean.

Pull Requests will only be considered if they meet *all* of the following rules:

✅ **Type of Change**
- Must be a **bug fix** OR
- A **small and focused feature**

🚫 **What will be rejected**
- PRs that **rewrite or restructure large parts of the code**
- PRs that **introduce complex changes without clear explanation**
- PRs with code from AI **without proper testing**

💡 If Your PR Is Rejected

If this pull request doesn’t meet the guidelines and is closed, you are **still welcome to maintain your work in your own fork** of the project. Forks are a great way to experiment, extend functionality, or customize the project for your own use.

Thank you for contributing and respecting the project’s scope and maintainability goals!

-->

## Description

- Fix missing extension name on windows which cause downloading language server every time extension loaded