### PR TITLE
Feature/zed debugger

### DIFF
--- a/src/AltEditors/Zed/Cargo.toml
+++ b/src/AltEditors/Zed/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.1.0"
+zed_extension_api = "0.6.0"
+serde = { version = "1.0", features = ["derive"] }

--- a/src/AltEditors/Zed/Cargo.toml
+++ b/src/AltEditors/Zed/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.6.0"
+zed_extension_api = "0.7.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/AltEditors/Zed/debug_adapter_schemas/monodbg.json
+++ b/src/AltEditors/Zed/debug_adapter_schemas/monodbg.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Zed Mono Debug Adapter Protocol Configuration",
+  "description": "JSON schema for monodbg debug adapter protocol launch and attach configurations",
+  "type": "object",
+  "properties": {
+    "request": {
+      "type": "string",
+      "enum": ["launch", "attach"],
+      "description": "The request type - either 'launch' to start a new process or 'attach' to connect to an existing process"
+    }
+  },
+  "required": ["request"],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "request": {
+            "const": "launch"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "request": true,
+          "program": {
+            "type": "string",
+            "pattern": "\\.(dll|exe)$",
+            "description": "Path to the executable assembly (.dll or .exe) to launch. This is the main entry point of your .NET application. NetCoreDbg will use 'dotnet' as the runtime and pass this as the first argument."
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "description": "Command line arguments to pass to the program. These arguments are appended after the program path when launching with 'dotnet'."
+          },
+          "cwd": {
+            "type": "string",
+            "description": "Working directory for the launched process. This is crucial for .NET applications as it determines where configuration files (like appsettings.json), relative file paths, and other resources are resolved from. For ASP.NET Core apps, this affects content root discovery and static file serving. If not specified, defaults to the workspace root directory.",
+            "default": "${ZED_WORKTREE_ROOT}"
+          },
+          "env": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {},
+            "description": "Environment variables to set for the launched process. These are key-value pairs that will be available to your application at runtime."
+          },
+          "stopAtEntry": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to stop at the entry point (main method) of the program. When true, the debugger will break at the first line of user code, allowing you to step through from the very beginning."
+          },
+          "justMyCode": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable Just My Code debugging. When true, the debugger will only step through and break in user-written code, skipping framework and library code. This matches the default behavior of Microsoft's vsdbg."
+          },
+          "enableStepFiltering": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable step filtering to automatically step over properties, operators, and other code constructs that are typically not interesting during debugging. This matches the default behavior of Microsoft's vsdbg."
+          }
+        },
+        "required": ["program"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "request": {
+            "const": "attach"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "request": true,
+          "processId": {
+            "oneOf": [
+              {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Numeric process ID to attach to"
+              },
+              {
+                "type": "string",
+                "pattern": "^[0-9]+$",
+                "description": "String representation of process ID to attach to"
+              }
+            ],
+            "description": "The process ID of the running .NET application to attach to. Can be specified as a number or string representation of a number. The target process must be a .NET Core application with debugging enabled."
+          }
+        },
+        "required": ["processId"]
+      }
+    }
+  ]
+}

--- a/src/AltEditors/Zed/debug_adapter_schemas/ncdbg.json
+++ b/src/AltEditors/Zed/debug_adapter_schemas/ncdbg.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Zed NetCoreDbg Debug Adapter Protocol Configuration",
+  "description": "JSON schema for netcoredbg debug adapter protocol launch and attach configurations",
+  "type": "object",
+  "properties": {
+    "request": {
+      "type": "string",
+      "enum": ["launch", "attach"],
+      "description": "The request type - either 'launch' to start a new process or 'attach' to connect to an existing process"
+    }
+  },
+  "required": ["request"],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "request": {
+            "const": "launch"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "request": true,
+          "program": {
+            "type": "string",
+            "pattern": "\\.(dll|exe)$",
+            "description": "Path to the executable assembly (.dll or .exe) to launch. This is the main entry point of your .NET application. NetCoreDbg will use 'dotnet' as the runtime and pass this as the first argument."
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "description": "Command line arguments to pass to the program. These arguments are appended after the program path when launching with 'dotnet'."
+          },
+          "cwd": {
+            "type": "string",
+            "description": "Working directory for the launched process. This is crucial for .NET applications as it determines where configuration files (like appsettings.json), relative file paths, and other resources are resolved from. For ASP.NET Core apps, this affects content root discovery and static file serving. If not specified, defaults to the workspace root directory.",
+            "default": "${ZED_WORKTREE_ROOT}"
+          },
+          "env": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {},
+            "description": "Environment variables to set for the launched process. These are key-value pairs that will be available to your application at runtime."
+          },
+          "stopAtEntry": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to stop at the entry point (main method) of the program. When true, the debugger will break at the first line of user code, allowing you to step through from the very beginning."
+          },
+          "justMyCode": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable Just My Code debugging. When true, the debugger will only step through and break in user-written code, skipping framework and library code. This matches the default behavior of Microsoft's vsdbg."
+          },
+          "enableStepFiltering": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable step filtering to automatically step over properties, operators, and other code constructs that are typically not interesting during debugging. This matches the default behavior of Microsoft's vsdbg."
+          }
+        },
+        "required": ["program"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "request": {
+            "const": "attach"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "request": true,
+          "processId": {
+            "oneOf": [
+              {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Numeric process ID to attach to"
+              },
+              {
+                "type": "string",
+                "pattern": "^[0-9]+$",
+                "description": "String representation of process ID to attach to"
+              }
+            ],
+            "description": "The process ID of the running .NET application to attach to. Can be specified as a number or string representation of a number. The target process must be a .NET Core application with debugging enabled."
+          }
+        },
+        "required": ["processId"]
+      }
+    }
+  ]
+}

--- a/src/AltEditors/Zed/extension.toml
+++ b/src/AltEditors/Zed/extension.toml
@@ -13,3 +13,6 @@ languages = ["CSharp"]
 [grammars.c_sharp]
 repository = "https://github.com/tree-sitter/tree-sitter-c-sharp"
 commit = "dd5e59721a5f8dae34604060833902b882023aaf"
+
+[debug_adapters.monodbg]
+schema_path = "debug_adapter_schemas/monodbg.json"

--- a/src/AltEditors/Zed/extension.toml
+++ b/src/AltEditors/Zed/extension.toml
@@ -16,3 +16,6 @@ commit = "dd5e59721a5f8dae34604060833902b882023aaf"
 
 [debug_adapters.monodbg]
 schema_path = "debug_adapter_schemas/monodbg.json"
+
+[debug_adapters.ncdbg]
+schema_path = "debug_adapter_schemas/ncdbg.json"

--- a/src/AltEditors/Zed/src/debugger.rs
+++ b/src/AltEditors/Zed/src/debugger.rs
@@ -1,0 +1,1 @@
+pub mod mono;

--- a/src/AltEditors/Zed/src/debugger.rs
+++ b/src/AltEditors/Zed/src/debugger.rs
@@ -1,1 +1,31 @@
 pub mod mono;
+pub mod ncdbg;
+
+use crate::{utils, ROOT_DIR};
+
+use serde::{Deserialize, Serialize};
+use zed_extension_api::{self as zed};
+
+/// Represents a process id that can be either an integer or a string (containing a number)
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum ProcessId {
+    Int(i32),
+    String(String),
+}
+
+pub(super) fn get_binary_abs_common(path: &str) -> Result<String, String> {
+    let (platform, _) = zed::current_platform();
+
+    let binary_path = utils::get_absolute_path(match platform {
+        zed::Os::Windows => format!("{}/{}.exe", ROOT_DIR, path),
+        _ => format!("{}/{}", ROOT_DIR, path),
+    })
+    .map_err(|e| format!("Cannot get {}: {}", path, e))?;
+
+    let mut path = binary_path.to_string_lossy().to_string();
+    // remove the weird directory slash at beginning of path
+    path.remove(0);
+
+    Ok(path)
+}

--- a/src/AltEditors/Zed/src/debugger.rs
+++ b/src/AltEditors/Zed/src/debugger.rs
@@ -23,9 +23,5 @@ pub(super) fn get_binary_abs_common(path: &str) -> Result<String, String> {
     })
     .map_err(|e| format!("Cannot get {}: {}", path, e))?;
 
-    let mut path = binary_path.to_string_lossy().to_string();
-    // remove the weird directory slash at beginning of path
-    path.remove(0);
-
-    Ok(path)
+    Ok(binary_path.to_string_lossy().to_string())
 }

--- a/src/AltEditors/Zed/src/debugger/mono.rs
+++ b/src/AltEditors/Zed/src/debugger/mono.rs
@@ -9,7 +9,7 @@ use zed_extension_api::{
     DebugScenario, DebugTaskDefinition, StartDebuggingRequestArguments, Worktree,
 };
 
-use crate::utils;
+use crate::{debugger::get_binary_abs_common};
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -24,19 +24,11 @@ struct MonoDebugConfig {
     #[serde(default)]
     pub env: HashMap<String, String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub process_id: Option<ProcessId>,
+    pub process_id: Option<super::ProcessId>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub debugger_options: Option<DebuggerOptions>,
     #[serde(default, rename = "type", skip_serializing_if = "Option::is_none")]
     pub ttype: Option<String>,
-}
-
-/// Represents a process id that can be either an integer or a string (containing a number)
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum ProcessId {
-    Int(i32),
-    String(String),
 }
 
 impl MonoDebugConfig {
@@ -76,13 +68,7 @@ pub fn get_dap_binary(
     _user_provided_debug_adapter_path: Option<String>,
     worktree: &Worktree,
 ) -> zed::Result<DebugAdapterBinary, String> {
-    let (platform, _) = zed::current_platform();
-
-    let binary_path = utils::get_absolute_path(match platform {
-        zed::Os::Windows => "./bin/DebuggerMono/monodbg.exe",
-        _ => "./bin/DebuggerMono/monodbg",
-    })
-    .map_err(|e| format!("Cannot get monodbg binary path: {}", e))?;
+    let binary_path = get_binary_abs_common("DebuggerMono/monodbg")?;
 
     if !(fs::metadata(&binary_path).map_or(false, |stat| stat.is_file())) {
         return Err("Cannot find monodbg binary".to_string());
@@ -103,11 +89,8 @@ pub fn get_dap_binary(
         }
     };
 
-    let mut path = binary_path.to_string_lossy().to_string();
-    // remove the weird directory slash at beginning of path
-    path.remove(0);
     Ok(zed::DebugAdapterBinary {
-        command: Some(path),
+        command: Some(binary_path),
         arguments: vec![],
         envs: dbg_config.env.into_iter().collect(),
         cwd: Some(dbg_config.cwd.unwrap_or_else(|| worktree.root_path())),

--- a/src/AltEditors/Zed/src/debugger/mono.rs
+++ b/src/AltEditors/Zed/src/debugger/mono.rs
@@ -1,0 +1,139 @@
+mod types;
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use types::DebuggerOptions;
+use zed_extension_api::{
+    self as zed, serde_json, AttachRequest, DebugAdapterBinary, DebugConfig, DebugRequest,
+    DebugScenario, DebugTaskDefinition, StartDebuggingRequestArguments, Worktree,
+};
+
+use crate::utils;
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct MonoDebugConfig {
+    pub request: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub program: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub args: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process_id: Option<ProcessId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub debugger_options: Option<DebuggerOptions>,
+    #[serde(default, rename = "type", skip_serializing_if = "Option::is_none")]
+    pub ttype: Option<String>,
+}
+
+/// Represents a process id that can be either an integer or a string (containing a number)
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum ProcessId {
+    Int(i32),
+    String(String),
+}
+
+impl MonoDebugConfig {
+    fn default_attach(config: DebugConfig, attach: AttachRequest) -> Result<DebugScenario, String> {
+        if attach.process_id.is_none() {
+            return Err("process_id is required".to_string());
+        }
+
+        // process id select from zed
+        // let process_id = ProcessId::Int(attach.process_id.unwrap() as i32);
+
+        let mono_debug_config = Self {
+            request: "attach".to_string(),
+            program: None,
+            args: None,
+            cwd: None,
+            env: HashMap::new(),
+            process_id: None,
+            debugger_options: Some(DebuggerOptions::default()),
+            ttype: Some("unity".to_string()),
+        };
+        let json = serde_json::to_string(&mono_debug_config)
+            .map_err(|e| format!("Failed to serialized attach config: {}", e))?;
+
+        Ok(DebugScenario {
+            label: config.label,
+            adapter: config.adapter,
+            build: None,
+            config: json,
+            tcp_connection: None,
+        })
+    }
+}
+
+pub fn get_dap_binary(
+    config: DebugTaskDefinition,
+    _user_provided_debug_adapter_path: Option<String>,
+    worktree: &Worktree,
+) -> zed::Result<DebugAdapterBinary, String> {
+    let (platform, _) = zed::current_platform();
+
+    let binary_path = utils::get_absolute_path(match platform {
+        zed::Os::Windows => "./bin/DebuggerMono/monodbg.exe",
+        _ => "./bin/DebuggerMono/monodbg",
+    })
+    .map_err(|e| format!("Cannot get monodbg binary path: {}", e))?;
+
+    if !(fs::metadata(&binary_path).map_or(false, |stat| stat.is_file())) {
+        return Err("Cannot find monodbg binary".to_string());
+    }
+
+    let configuration = config.config.to_string();
+    let dbg_config: MonoDebugConfig =
+        serde_json::from_str(&configuration).map_err(|e| e.to_string())?;
+
+    let request = match dbg_config.request.as_str() {
+        "launch" => zed::StartDebuggingRequestArgumentsRequest::Launch,
+        "attach" => zed::StartDebuggingRequestArgumentsRequest::Attach,
+        unknown => {
+            return Err(format!(
+                "Invalid 'request' value: '{}'. Expected 'launch' or 'attach'",
+                unknown
+            ));
+        }
+    };
+
+    let mut path = binary_path.to_string_lossy().to_string();
+    // remove the weird directory slash at beginning of path
+    path.remove(0);
+    Ok(zed::DebugAdapterBinary {
+        command: Some(path),
+        arguments: vec![],
+        envs: dbg_config.env.into_iter().collect(),
+        cwd: Some(dbg_config.cwd.unwrap_or_else(|| worktree.root_path())),
+        connection: None,
+        request_args: StartDebuggingRequestArguments {
+            configuration,
+            request,
+        },
+    })
+}
+
+pub fn dap_request_kind(
+    config: zed_extension_api::serde_json::Value,
+) -> zed::Result<zed::StartDebuggingRequestArgumentsRequest, String> {
+    match config.get("request").and_then(|v| v.as_str()) {
+        Some("launch") => Ok(zed::StartDebuggingRequestArgumentsRequest::Launch),
+        Some("attach") => Ok(zed::StartDebuggingRequestArgumentsRequest::Attach),
+        _ => Err("Invalid request".to_string()),
+    }
+}
+
+pub fn dap_config_to_scenario(
+    config: DebugConfig,
+) -> zed_extension_api::Result<zed_extension_api::DebugScenario, String> {
+    match config.request {
+        DebugRequest::Launch(_launch) => Err("Launch not implemented".to_string()),
+        DebugRequest::Attach(attach) => MonoDebugConfig::default_attach(config, attach),
+    }
+}

--- a/src/AltEditors/Zed/src/debugger/mono/types.rs
+++ b/src/AltEditors/Zed/src/debugger/mono/types.rs
@@ -1,0 +1,111 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DebuggerOptions {
+    pub evaluation_options: EvaluationOptions,
+    pub step_over_properties_and_operators: bool,
+    pub project_assemblies_only: bool,
+    pub automatic_source_link_download: bool,
+    pub debug_subprocesses: bool,
+    pub symbol_search_paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_code_mappings: Option<HashMap<String, String>>,
+    pub search_microsoft_symbol_server: bool,
+    pub search_nu_get_symbol_server: bool,
+    pub skip_native_transitions: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EvaluationOptions {
+    pub evaluation_timeout: u32,
+    pub member_evaluation_timeout: u32,
+    pub allow_target_invoke: bool,
+    pub allow_method_evaluation: bool,
+    pub allow_to_string_calls: bool,
+    pub flatten_hierarchy: bool,
+    pub group_private_members: bool,
+    pub group_static_members: bool,
+    pub use_external_type_resolver: bool,
+    pub integer_display_format: IntegerDisplayFormat,
+    pub current_exception_tag: String,
+    pub ellipsize_strings: bool,
+    pub ellipsized_length: u32,
+    pub chunk_raw_strings: bool,
+    pub stack_frame_format: StackFrameFormat,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum IntegerDisplayFormat {
+    Decimal,
+    Hexadecimal,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StackFrameFormat {
+    pub line: bool,
+    pub module: bool,
+    pub parameter_names: bool,
+    pub parameter_types: bool,
+    pub parameter_values: bool,
+    pub language: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_code: Option<bool>,
+}
+
+impl Default for DebuggerOptions {
+    fn default() -> Self {
+        Self {
+            evaluation_options: Default::default(),
+            step_over_properties_and_operators: true,
+            project_assemblies_only: true,
+            automatic_source_link_download: true,
+            debug_subprocesses: false,
+            symbol_search_paths: vec![],
+            source_code_mappings: None,
+            search_microsoft_symbol_server: false,
+            search_nu_get_symbol_server: false,
+            skip_native_transitions: true,
+        }
+    }
+}
+
+impl Default for EvaluationOptions {
+    fn default() -> Self {
+        Self {
+            evaluation_timeout: 1000,
+            member_evaluation_timeout: 5000,
+            allow_target_invoke: true,
+            allow_method_evaluation: true,
+            allow_to_string_calls: true,
+            flatten_hierarchy: false,
+            group_private_members: true,
+            group_static_members: true,
+            use_external_type_resolver: true,
+            integer_display_format: IntegerDisplayFormat::Decimal,
+            current_exception_tag: "$exception".to_string(),
+            ellipsize_strings: true,
+            ellipsized_length: 100,
+            chunk_raw_strings: false,
+            stack_frame_format: Default::default(),
+        }
+    }
+}
+
+impl Default for StackFrameFormat {
+    fn default() -> Self {
+        Self {
+            line: false,
+            module: true,
+            parameter_names: false,
+            parameter_types: false,
+            parameter_values: false,
+            language: false,
+            external_code: None,
+        }
+    }
+}

--- a/src/AltEditors/Zed/src/debugger/ncdbg.rs
+++ b/src/AltEditors/Zed/src/debugger/ncdbg.rs
@@ -89,37 +89,49 @@ pub fn dap_request_kind(
 pub fn dap_config_to_scenario(
     config: DebugConfig,
 ) -> zed_extension_api::Result<zed_extension_api::DebugScenario, String> {
-    match config.request {
-        DebugRequest::Launch(launch) => {
-            let dap_config = NetCoreDebugConfig {
-                request: "launch".to_string(),
-                program: Some(launch.program),
-                args: if launch.args.is_empty() {
-                    None
-                } else {
-                    Some(launch.args)
-                },
-                cwd: launch.cwd,
-                env: launch.envs.into_iter().collect(),
-                stop_at_entry: None,
+    let dap_config = match config.request {
+        DebugRequest::Launch(launch) => NetCoreDebugConfig {
+            request: "launch".to_string(),
+            program: Some(launch.program),
+            args: if launch.args.is_empty() {
+                None
+            } else {
+                Some(launch.args)
+            },
+            cwd: launch.cwd,
+            env: launch.envs.into_iter().collect(),
+            stop_at_entry: None,
+            just_my_code: None,
+            enable_step_filtering: None,
+            process_id: None,
+        },
+        DebugRequest::Attach(attach) => {
+            let pid = attach.process_id.ok_or("process_id not provided")?;
+
+            NetCoreDebugConfig {
+                request: "attach".to_string(),
+                program: None,
+                args: None,
+                cwd: None,
+                env: HashMap::new(),
+                stop_at_entry: config.stop_on_entry,
                 just_my_code: None,
                 enable_step_filtering: None,
-                process_id: None,
-            };
-
-            let json = serde_json::to_string(&dap_config)
-                .map_err(|e| format!("Failed to serialize NetCoreDebugConfig: {}", e))?;
-
-            Ok(DebugScenario {
-                label: config.label,
-                adapter: config.adapter,
-                build: None,
-                config: json,
-                tcp_connection: None,
-            })
+                process_id: Some(crate::debugger::ProcessId::Int(pid as i32)),
+            }
         }
-        DebugRequest::Attach(_attach) => Err("Launch not implemented".to_string()),
-    }
+    };
+
+    let json = serde_json::to_string(&dap_config)
+        .map_err(|e| format!("Failed to serialize NetCoreDebugConfig: {}", e))?;
+
+    Ok(DebugScenario {
+        label: config.label,
+        adapter: config.adapter,
+        build: None,
+        config: json,
+        tcp_connection: None,
+    })
 }
 
 fn download_netcoredbg() -> Result<String, String> {

--- a/src/AltEditors/Zed/src/debugger/ncdbg.rs
+++ b/src/AltEditors/Zed/src/debugger/ncdbg.rs
@@ -1,0 +1,187 @@
+// ref: https://github.com/qwadrox/zed-netcoredbg
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use zed_extension_api::{
+    self as zed, serde_json, DebugAdapterBinary, DebugConfig, DebugRequest, DebugScenario,
+    DebugTaskDefinition, StartDebuggingRequestArguments, Worktree,
+};
+
+use crate::{debugger::get_binary_abs_common, ROOT_DIR};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct NetCoreDebugConfig {
+    pub request: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub program: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub args: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_at_entry: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub just_my_code: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enable_step_filtering: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process_id: Option<super::ProcessId>,
+}
+
+const REPO_SOURCE: &str = "Samsung/netcoredbg";
+const BASE_DIR: &str = "Debugger";
+const BINARY_PATH: &str = "netcoredbg/netcoredbg";
+
+pub fn get_dap_binary(
+    config: DebugTaskDefinition,
+    _user_provided_debug_adapter_path: Option<String>,
+    worktree: &Worktree,
+) -> zed::Result<DebugAdapterBinary, String> {
+    let configuration = config.config.to_string();
+    let dbg_config: NetCoreDebugConfig =
+        serde_json::from_str(&configuration).map_err(|e| e.to_string())?;
+
+    let request = match dbg_config.request.as_str() {
+        "launch" => zed::StartDebuggingRequestArgumentsRequest::Launch,
+        "attach" => zed::StartDebuggingRequestArgumentsRequest::Attach,
+        unknown => {
+            return Err(format!(
+                "Invalid 'request' value: '{}'. Expected 'launch' or 'attach'",
+                unknown
+            ));
+        }
+    };
+
+    let binary_path = get_binary_path(false)?;
+    let dab = zed::DebugAdapterBinary {
+        command: if fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
+            Some(get_binary_path(true)?)
+        } else {
+            Some(download_netcoredbg()?)
+        },
+        arguments: vec!["--interpreter=vscode".to_string()],
+        envs: dbg_config.env.into_iter().collect(),
+        cwd: Some(dbg_config.cwd.unwrap_or_else(|| worktree.root_path())),
+        connection: None,
+        request_args: StartDebuggingRequestArguments {
+            configuration,
+            request,
+        },
+    };
+
+    Ok(dab)
+}
+
+pub fn dap_request_kind(
+    config: zed_extension_api::serde_json::Value,
+) -> zed::Result<zed::StartDebuggingRequestArgumentsRequest, String> {
+    match config.get("request").and_then(|v| v.as_str()) {
+        Some("launch") => Ok(zed::StartDebuggingRequestArgumentsRequest::Launch),
+        Some("attach") => Ok(zed::StartDebuggingRequestArgumentsRequest::Attach),
+        _ => Err("Invalid request".to_string()),
+    }
+}
+
+pub fn dap_config_to_scenario(
+    config: DebugConfig,
+) -> zed_extension_api::Result<zed_extension_api::DebugScenario, String> {
+    match config.request {
+        DebugRequest::Launch(launch) => {
+            let dap_config = NetCoreDebugConfig {
+                request: "launch".to_string(),
+                program: Some(launch.program),
+                args: if launch.args.is_empty() {
+                    None
+                } else {
+                    Some(launch.args)
+                },
+                cwd: launch.cwd,
+                env: launch.envs.into_iter().collect(),
+                stop_at_entry: None,
+                just_my_code: None,
+                enable_step_filtering: None,
+                process_id: None,
+            };
+
+            let json = serde_json::to_string(&dap_config)
+                .map_err(|e| format!("Failed to serialize NetCoreDebugConfig: {}", e))?;
+
+            Ok(DebugScenario {
+                label: config.label,
+                adapter: config.adapter,
+                build: None,
+                config: json,
+                tcp_connection: None,
+            })
+        }
+        DebugRequest::Attach(_attach) => Err("Launch not implemented".to_string()),
+    }
+}
+
+fn download_netcoredbg() -> Result<String, String> {
+    let release = zed::latest_github_release(
+        REPO_SOURCE,
+        zed::GithubReleaseOptions {
+            require_assets: true,
+            pre_release: false,
+        },
+    )?;
+
+    let (platform, arch) = zed::current_platform();
+
+    let asset_name = match platform {
+        zed::Os::Windows => "netcoredbg-win64.zip".to_string(),
+        os => format!(
+            "netcoredbg-{os}-{arch}.tar.gz",
+            os = match os {
+                zed::Os::Mac => "osx",
+                zed::Os::Linux => "linux",
+                _ => "unknown",
+            },
+            arch = match arch {
+                zed::Architecture::Aarch64 => "arm64",
+                zed::Architecture::X8664 => "amd64",
+                zed::Architecture::X86 => todo!(),
+            }
+        ),
+    };
+
+    let asset = release
+        .assets
+        .into_iter()
+        .find(|asset| asset.name == asset_name)
+        .ok_or_else(|| format!("Asset not found: {}", asset_name))?;
+
+    zed::download_file(
+        &asset.download_url,
+        format!("{}/{}", ROOT_DIR, BASE_DIR).as_str(),
+        zed::DownloadedFileType::Zip,
+    )
+    .map_err(|e| format!("failed to download file: {e}"))?;
+
+    let binary_path = get_binary_path(false)?;
+
+    if fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
+        zed::make_file_executable(&binary_path)?;
+        return Ok(get_binary_path(true)?);
+    }
+
+    Err("failed to download binary".to_string())
+}
+
+fn get_binary_path(abs: bool) -> Result<String, String> {
+    let (platform, _) = zed::current_platform();
+
+    if abs {
+        return get_binary_abs_common(format!("{}/{}", BASE_DIR, BINARY_PATH).as_str());
+    }
+
+    Ok(match platform {
+        zed::Os::Windows => format!("{}/{}/{}.exe", ROOT_DIR, BASE_DIR, BINARY_PATH),
+        _ => format!("{}/{}/{}", ROOT_DIR, BASE_DIR, BINARY_PATH),
+    })
+}

--- a/src/AltEditors/Zed/src/lib.rs
+++ b/src/AltEditors/Zed/src/lib.rs
@@ -1,32 +1,34 @@
+mod debugger;
+mod utils;
+mod vsx_handler;
+
 use std::fs;
-use zed_extension_api::{self as zed, LanguageServerId, Result, Worktree};
 use zed::serde_json;
 use zed_extension_api::settings::LspSettings;
+use zed_extension_api::{
+    self as zed, DebugAdapterBinary, DebugConfig, DebugTaskDefinition, LanguageServerId, Result,
+    Worktree,
+};
 
 struct DotRushExtension {}
 impl DotRushExtension {
     fn language_server_binary(&mut self, language_server_id: &LanguageServerId) -> Result<String> {
         let (platform, arch) = zed::current_platform();
 
-        let binary_dir = "./LanguageServer".to_string();
         let binary_path = match platform {
-            zed::Os::Windows => "./LanguageServer/DotRush.exe",
-            _ => "./LanguageServer/DotRush"
-        }.to_string();
+            zed::Os::Windows => "./bin/LanguageServer/DotRush.exe",
+            _ => "./bin/LanguageServer/DotRush",
+        }
+        .to_string();
+
         if fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
             return Ok(binary_path);
         }
 
-        let release = zed::latest_github_release(
-            "JaneySprings/DotRush",
-            zed::GithubReleaseOptions {
-                require_assets: true,
-                pre_release: false,
-            },
-        )?;
+        let vsx_info = vsx_handler::fetch_vsx_info()?;
 
-        let asset_name = format!(
-            "DotRush.Bundle.Server_{os}-{arch}.zip",
+        let target_arch = format!(
+            "{os}-{arch}",
             os = match platform {
                 zed::Os::Mac => "darwin",
                 zed::Os::Linux => "linux",
@@ -39,23 +41,12 @@ impl DotRushExtension {
             }
         );
 
-        let asset = release
-            .assets
-            .iter()
-            .find(|asset| asset.name == asset_name)
-            .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
-
         zed::set_language_server_installation_status(
             language_server_id,
             &zed::LanguageServerInstallationStatus::Downloading,
         );
 
-        zed::download_file(
-            &asset.download_url,
-            &binary_dir,
-            zed::DownloadedFileType::Zip,
-        )
-        .map_err(|e| format!("failed to download file: {e}"))?;
+        vsx_handler::download_vsx(vsx_info, &target_arch)?;
 
         Ok(binary_path)
     }
@@ -90,6 +81,42 @@ impl zed::Extension for DotRushExtension {
             .and_then(|lsp_settings| lsp_settings.settings.clone())
             .unwrap_or_default();
         Ok(Some(settings))
+    }
+
+    fn get_dap_binary(
+        &mut self,
+        adapter_name: String,
+        config: DebugTaskDefinition,
+        user_provided_debug_adapter_path: Option<String>,
+        worktree: &Worktree,
+    ) -> zed::Result<DebugAdapterBinary, String> {
+        match adapter_name.as_str() {
+            "monodbg" => {
+                debugger::mono::get_dap_binary(config, user_provided_debug_adapter_path, worktree)
+            }
+            _ => todo!(),
+        }
+    }
+
+    fn dap_request_kind(
+        &mut self,
+        adapter_name: String,
+        config: zed_extension_api::serde_json::Value,
+    ) -> zed::Result<zed::StartDebuggingRequestArgumentsRequest, String> {
+        match adapter_name.as_str() {
+            "monodbg" => debugger::mono::dap_request_kind(config),
+            _ => todo!(),
+        }
+    }
+
+    fn dap_config_to_scenario(
+        &mut self,
+        config: DebugConfig,
+    ) -> zed_extension_api::Result<zed_extension_api::DebugScenario, String> {
+        match config.adapter.as_str() {
+            "monodbg" => debugger::mono::dap_config_to_scenario(config),
+            _ => todo!(),
+        }
     }
 }
 

--- a/src/AltEditors/Zed/src/lib.rs
+++ b/src/AltEditors/Zed/src/lib.rs
@@ -10,6 +10,8 @@ use zed_extension_api::{
     Worktree,
 };
 
+pub(crate) const ROOT_DIR: &str = "./bin";
+
 struct DotRushExtension {}
 impl DotRushExtension {
     fn language_server_binary(&mut self, language_server_id: &LanguageServerId) -> Result<String> {
@@ -94,6 +96,9 @@ impl zed::Extension for DotRushExtension {
             "monodbg" => {
                 debugger::mono::get_dap_binary(config, user_provided_debug_adapter_path, worktree)
             }
+            "ncdbg" => {
+                debugger::ncdbg::get_dap_binary(config, user_provided_debug_adapter_path, worktree)
+            }
             _ => todo!(),
         }
     }
@@ -105,6 +110,7 @@ impl zed::Extension for DotRushExtension {
     ) -> zed::Result<zed::StartDebuggingRequestArgumentsRequest, String> {
         match adapter_name.as_str() {
             "monodbg" => debugger::mono::dap_request_kind(config),
+            "ncdbg" => debugger::ncdbg::dap_request_kind(config),
             _ => todo!(),
         }
     }
@@ -115,6 +121,7 @@ impl zed::Extension for DotRushExtension {
     ) -> zed_extension_api::Result<zed_extension_api::DebugScenario, String> {
         match config.adapter.as_str() {
             "monodbg" => debugger::mono::dap_config_to_scenario(config),
+            "ncdbg" => debugger::ncdbg::dap_config_to_scenario(config),
             _ => todo!(),
         }
     }

--- a/src/AltEditors/Zed/src/utils.rs
+++ b/src/AltEditors/Zed/src/utils.rs
@@ -1,0 +1,43 @@
+use std::{
+    collections::HashSet,
+    fs,
+    path::{Path, PathBuf},
+};
+
+/// Since fs::remove_dir_all is not work properly
+/// (dup remove entry / non-empty dir error)
+/// This function scan directory contents and remove them recursively
+pub(crate) fn remove_dir<P: AsRef<Path>>(path: P) -> std::io::Result<()> {
+    let paths = scan_dir_contents(&path)?;
+    let mut dir_vec: Vec<PathBuf> = vec![];
+    for path in paths {
+        if path.is_file() {
+            fs::remove_file(path)?;
+        } else {
+            dir_vec.push(path);
+        }
+    }
+    // reversed sorting by depth
+    dir_vec.sort_by(|a, b| b.cmp(a));
+    for dir in dir_vec {
+        fs::remove_dir_all(dir)?;
+    }
+
+    fs::remove_dir_all(path)?;
+    Ok(())
+}
+
+pub(crate) fn scan_dir_contents<P: AsRef<Path>>(path: P) -> std::io::Result<HashSet<PathBuf>> {
+    let mut paths = HashSet::new();
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if entry.file_type()?.is_dir() {
+            paths.extend(scan_dir_contents(&path)?);
+        }
+        paths.insert(path);
+    }
+
+    Ok(paths)
+}

--- a/src/AltEditors/Zed/src/utils.rs
+++ b/src/AltEditors/Zed/src/utils.rs
@@ -41,3 +41,8 @@ pub(crate) fn scan_dir_contents<P: AsRef<Path>>(path: P) -> std::io::Result<Hash
 
     Ok(paths)
 }
+
+pub(crate) fn get_absolute_path<P: AsRef<Path>>(rel_path: P) -> std::io::Result<PathBuf> {
+    let root = std::env::current_dir()?;
+    Ok(root.join(rel_path))
+}

--- a/src/AltEditors/Zed/src/vsx_handler.rs
+++ b/src/AltEditors/Zed/src/vsx_handler.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fs, path::PathBuf, sync::OnceLock};
-use zed_extension_api::{self as zed, http_client::*, serde_json, Architecture};
+use std::{collections::HashMap, fs};
+use zed_extension_api::{self as zed, http_client::*, serde_json};
 
 use crate::utils;
 
@@ -38,7 +38,7 @@ pub fn download_vsx(vsx_info: VsxInfo, arch: &str) -> Result<String, String> {
     zed::download_file(download_url, "./temp", zed::DownloadedFileType::Zip)?;
 
     // move extracted files to bin directory
-    fs::rename("./temp/extension/extension/bin", format!("./bin/{}", arch))
+    fs::rename("./temp/extension/extension/bin", "./bin")
         .map_err(|e| format!("Failed to move binary directory: {}", e))?;
 
     utils::remove_dir("./temp").map_err(|e| format!("Failed to remove temp vsx folder: {}", e))?;

--- a/src/AltEditors/Zed/src/vsx_handler.rs
+++ b/src/AltEditors/Zed/src/vsx_handler.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fs};
 use zed_extension_api::{self as zed, http_client::*, serde_json};
 
-use crate::utils;
+use crate::{utils, ROOT_DIR};
 
 #[derive(Default, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -38,7 +38,7 @@ pub fn download_vsx(vsx_info: VsxInfo, arch: &str) -> Result<String, String> {
     zed::download_file(download_url, "./temp", zed::DownloadedFileType::Zip)?;
 
     // move extracted files to bin directory
-    fs::rename("./temp/extension/extension/bin", "./bin")
+    fs::rename("./temp/extension/extension/bin", ROOT_DIR)
         .map_err(|e| format!("Failed to move binary directory: {}", e))?;
 
     utils::remove_dir("./temp").map_err(|e| format!("Failed to remove temp vsx folder: {}", e))?;

--- a/src/AltEditors/Zed/src/vsx_handler.rs
+++ b/src/AltEditors/Zed/src/vsx_handler.rs
@@ -1,0 +1,50 @@
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, fs, path::PathBuf, sync::OnceLock};
+use zed_extension_api::{self as zed, http_client::*, serde_json, Architecture};
+
+use crate::utils;
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct VsxInfo {
+    #[serde(default)]
+    version: String,
+    #[serde(default, rename = "downloads")]
+    downloads: HashMap<String, String>,
+}
+
+pub fn fetch_vsx_info() -> Result<VsxInfo, String> {
+    let response = HttpRequestBuilder::new()
+        .method(HttpMethod::Get)
+        .url("https://open-vsx.org/api/nromanov/dotrush/latest")
+        .build()?
+        .fetch();
+
+    response
+        .map_err(|e| format!("Failed to fetch from open VSX: {}", e))
+        .and_then(|r| {
+            serde_json::from_slice(&r.body)
+                .map_err(|e| format!("Failed deserialize vsx body json: {}", e))
+        })
+}
+
+pub fn download_vsx(vsx_info: VsxInfo, arch: &str) -> Result<String, String> {
+    let download_url = vsx_info
+        .downloads
+        .get(arch)
+        .ok_or("No download URL found")?;
+
+    // VSX can be treated as a zip file and extracted properly
+    zed::download_file(download_url, "./temp", zed::DownloadedFileType::Zip)?;
+
+    // move extracted files to bin directory
+    fs::rename("./temp/extension/extension/bin", format!("./bin/{}", arch))
+        .map_err(|e| format!("Failed to move binary directory: {}", e))?;
+
+    utils::remove_dir("./temp").map_err(|e| format!("Failed to remove temp vsx folder: {}", e))?;
+
+    Ok(format!(
+        "Downloaded VSX successfully from: {}",
+        download_url
+    ))
+}

--- a/src/DotRush.Debugging.Mono/LaunchConfiguration.cs
+++ b/src/DotRush.Debugging.Mono/LaunchConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using DotRush.Common.Extensions;
+﻿﻿using DotRush.Common.Extensions;
 using DotRush.Debugging.Mono.Extensions;
 using Mono.Debugging.Client;
 using Newtonsoft.Json.Linq;


### PR DESCRIPTION
<!--
🚨 Pull Request Guidelines — Please Read Before Submitting

I want to keep this project maintainable, understandable, and clean.

Pull Requests will only be considered if they meet *all* of the following rules:

✅ **Type of Change**
- Must be a **bug fix** OR
- A **small and focused feature**

🚫 **What will be rejected**
- PRs that **rewrite or restructure large parts of the code**
- PRs that **introduce complex changes without clear explanation**
- PRs with code from AI **without proper testing**

💡 If Your PR Is Rejected

If this pull request doesn’t meet the guidelines and is closed, you are **still welcome to maintain your work in your own fork** of the project. Forks are a great way to experiment, extend functionality, or customize the project for your own use.

Thank you for contributing and respecting the project’s scope and maintainability goals!

-->

## Description

Adding debugger to zed

## Features and Key Changes

- No longer download the language server from git, instead, fetch version from [OpenVsx](https://open-vsx.org/api/nromanov/dotrush/latest) (since vsix market cannot download the archives), download the latest one and unzip with zed extension api builtin methods
- Add `monodbg` for unity dev, which has contained in full vsx bundle
- Add `netcoredbg` (reference to @qwadrox 's nice debugger implement), fetch the debugger binary from [Samsung/netcoredbg](https://github.com/Samsung/netcoredbg)
- Add debugger json schema
- Update `extension.toml` with two debugger